### PR TITLE
Fix schedule_expression implementation to match variable definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -205,10 +205,10 @@ resource "aws_imagebuilder_image_pipeline" "imagebuilder_image_pipeline" {
   infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.imagebuilder_infrastructure_configuration[count.index].arn
   distribution_configuration_arn   = try(aws_imagebuilder_distribution_configuration.imagebuilder_distribution_configuration[count.index].arn, null)
   dynamic "schedule" {
-    for_each = try(var.schedule_expression, tomap({}))
+    for_each = try(var.schedule_expression, [])
     content {
-      schedule_expression                = schedule.key
-      pipeline_execution_start_condition = schedule.value
+      schedule_expression                = schedule.value.scheduleExpression
+      pipeline_execution_start_condition = schedule.value.pipeline_execution_start_condition
     }
   }
   name = "${var.name}-pipeline"


### PR DESCRIPTION
Fixes the issue #107 

In `variables.tf`, it's defined as a list of objects:
```hcl
type = list(object({
  pipeline_execution_start_condition = string,
  scheduleExpression = string
}))
```
But in main.tf, it's used as a map:
```
for_each = try(var.schedule_expression, tomap({}))
content {
  schedule_expression = schedule.key
  pipeline_execution_start_condition = schedule.value
}
```
This causes errors when users follow the documented variable format.

## Changes Made
Updated the dynamic block to correctly use the properties from the list of objects, making the implementation match the variable definition.

## Testing Done
 - Verified terraform validate passes
 - Ran all required checks (tflint, tfsec, markdown lint, checkov)
 - Confirmed the module works with the documented input format

This fixes users' ability to create scheduled pipelines using the documented format.